### PR TITLE
fix: Configure Vite for multi-page deployment

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,13 @@
+import { resolve } from 'path';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        login: resolve(__dirname, 'login.html'),
+      },
+    },
+  },
+});


### PR DESCRIPTION
**Problem:**
The deployment on Vercel resulted in a `404 Not Found` error. This happened when the application, running on `index.html`, correctly identified an unauthenticated user and tried to redirect to `login.html`. Vercel was not aware of the `login.html` file and could not serve it.

**Solution:**
Introduces a `vite.config.js` file at the root of the `frontend` project. This configuration explicitly defines both `index.html` and `login.html` as entry points for the build process.

**Outcome:**
With this change, Vite will build both pages as part of the deployment output. Vercel will now be able to serve both `/` (for `index.html`) and `/login.html`, resolving the 404 error and fixing the login redirect loop.