### PR TITLE
fix: Configure CORS for production

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -8,8 +8,11 @@ const app = express();
 const port = 3001;
 
 
-app.use(cors());
-app.use(express.json());
+const corsOptions = {
+  origin: 'employee-recommendation-app.vercel.app'
+};
+
+app.use(cors(corsOptions));app.use(express.json());
 
 app.use('/api/referrals', referralRoutes);
 app.use('/api/auth', authRoutes);


### PR DESCRIPTION
**Problem:**
The deployed frontend application on Vercel was unable to make API calls to the deployed backend on Render, resulting in a "Failed to fetch" error. This was caused by the backend's default CORS policy, which did not explicitly allow requests from the Vercel domain.

**Solution:**
Updates the CORS middleware configuration in `backend/server.js`. The origin is now explicitly set to the production frontend URL hosted on Vercel.