### PR TITLE
fix: Use dynamic port for production deployment

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -5,8 +5,8 @@ const referralRoutes = require('./routes/referrals');
 const authRoutes = require('./routes/auth');
 
 const app = express();
-const port = 3001;
 
+const port = process.env.PORT || 3001;
 
 const corsOptions = {
   origin: 'employee-recommendation-app.vercel.app'


### PR DESCRIPTION
**Problem:**
The backend service was failing to deploy correctly on Render. The logs indicated that the service started but was not reachable, leading to a "Failed to fetch" error from the frontend. The root cause was that the server was hardcoded to listen on port `3001`, while Render assigns a dynamic port for production environments.

**Solution:**
Modifies the `backend/server.js` file to listen on the port provided by the hosting environment's `PORT` environment variable. A fallback to port `3001` is kept for local development.