### PR TITLE
Fix/prod connection

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -1,13 +1,13 @@
 require('dotenv').config();
-
 const { Pool } = require('pg');
 
 const pool = new Pool({
-  user: process.env.DB_USER,
-  host: process.env.DB_HOST,
-  database: process.env.DB_DATABASE,
-  password: process.env.DB_PASSWORD,
-  port: process.env.DB_PORT,
+
+  connectionString: process.env.DATABASE_URL,
+
+  ssl: {
+    rejectUnauthorized: false
+  }
 });
 
 module.exports = pool;

--- a/backend/server.js
+++ b/backend/server.js
@@ -17,6 +17,6 @@ app.use(cors(corsOptions));app.use(express.json());
 app.use('/api/referrals', referralRoutes);
 app.use('/api/auth', authRoutes);
 
-app.listen(port, () => {
-  console.log(`Server lauscht auf http://localhost:${port}`);
+app.listen(port, '0.0.0.0', () => {
+  console.log(`Server lauscht auf Port ${port}`);
 });

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,5 +1,10 @@
 
-DROP TABLE IF EXISTS referrals;
+CREATE TABLE users (
+    id SERIAL PRIMARY KEY,
+    email VARCHAR(255) UNIQUE NOT NULL,
+    password_hash VARCHAR(255) NOT NULL,
+    role VARCHAR(50) NOT NULL DEFAULT 'employee'
+);
 
 CREATE TABLE referrals (
     
@@ -8,12 +13,12 @@ CREATE TABLE referrals (
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     user_id INTEGER REFERENCES users(id),
 
- 
+   
     first_name VARCHAR(255) NOT NULL,
     last_name VARCHAR(255),
     email VARCHAR(255),
     phone_number VARCHAR(100),
-    contact_source TEXT,
+    contact_source TEXT, 
     first_contact_date DATE,
     convinced_date DATE,
 
@@ -42,12 +47,12 @@ CREATE TABLE referrals (
     
     skills JSONB,
 
-    
+ 
     personality_type VARCHAR(255),
     hobbies TEXT,
     project_experience TEXT,
     misc_notes TEXT,
-
     
-    cv_path VARCHAR(255) 
+   
+    cv_path VARCHAR(255)
 );


### PR DESCRIPTION
**Problem:**
The deployed backend service on Render was starting successfully but was unreachable from the internet, causing all API requests from the live frontend to fail. The logs showed the server was listening on `localhost`, which only accepts connections from within its own container.

**Solution:**
Modifies the `app.listen()` method in `backend/server.js` to explicitly bind to the host `0.0.0.0`. This makes the server listen on all available network interfaces, allowing it to accept public traffic routed to it by Render.