### PR TITLE
fix: Allow PATCH methods in CORS policy

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -16,7 +16,7 @@ const corsOptions = {
     'http://localhost:3000'
   ],
   credentials: true,
-  methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+  methods: ['GET', 'POST', 'PATCH' ,'PUT', 'DELETE', 'OPTIONS'],
   allowedHeaders: ['Content-Type', 'Authorization']
 };
 


### PR DESCRIPTION
**Problem:**
When trying to update a referral's status on the live application, the request was blocked by a CORS error. The browser's preflight `OPTIONS` request revealed that the `PATCH` method was not included in the `Access-Control-Allow-Methods` header of the server's response.

**Solution:**
Updates the `corsOptions` object in `backend/server.js` to explicitly include `PATCH` in the list of allowed HTTP methods.